### PR TITLE
Fix JavaScript on the instructor show page

### DIFF
--- a/app/views/instructor/courses/show.html.erb
+++ b/app/views/instructor/courses/show.html.erb
@@ -4,7 +4,6 @@
       var lessonUrl = $( event.target).data('lesson-url');
       $('#newLessonForm').attr('action', lessonUrl);
     });
-  $(function() {
     $('.sections').sortable({
       update: function( event, ui ) {
         $.ajax({
@@ -15,8 +14,6 @@
         });
       }
     });
-   });
-  $(function() {
     $('.lessons').sortable({
       update: function( event, ui ) {
         $.ajax({
@@ -50,7 +47,7 @@
         <%= section.title %>
       </div>
         <!-- Button trigger modal -->
-     <button class="btn btn-primary btn-sm pull-right" data-toggle="modal" data-target="#newLessonModal" data-lesson-url="<%= instructor_section_lessons_path(section) %>">
+     <button class="btn btn-primary btn-sm pull-right new-lesson-button" data-toggle="modal" data-target="#newLessonModal" data-lesson-url="<%= instructor_section_lessons_path(section) %>">
       New Lesson!
       </button>
 


### PR DESCRIPTION
In the JavaScript console, I saw an error message when the page loads:

http://take.ms/rayMa

It looked like we didn't have a balance of open parens and closing parens.  I adjusted the JavaScript code to have a single "on page load" javascript section and wrapped each of the three tasks within that one (alternatively you could have three separate ones).  I then balanced out the parens.

Next the button didn't have the class `new-lesson-button`.  That needs to have that class because we have this JavaScript code:
http://take.ms/NHInL

---

As a side note, this is a GitHub pull request. This is how I can show you code that I think you should add to your project. It allows you to look at the code, you'll see the green code is code that's added and the red is code that's deleted. The "Files changed" tab will show you the code.

"Commits" will show you a listing of the individual commits I'm trying to send you. And this tab, the conversation tab you can use to communicate about the change.

If you want to suck in all this code into your project you can by pressing the green merge button. After you press the merge button, you'll have to update your web dev environment to have the latest updates from GitHub and to do that you can run this command:

```
git pull origin master
```

Hope this helps.

Aloha,
Ken
